### PR TITLE
chore: Make AgeGroupRulesFactory and AgeGroupRule internal

### DIFF
--- a/BKRCalculator/AgeGroupRule.cs
+++ b/BKRCalculator/AgeGroupRule.cs
@@ -1,13 +1,13 @@
 namespace KDVManager.BKRCalculator;
 
-public class AgeGroupRule
+internal class AgeGroupRule
 {
     public int MinAge { get; }
     public int MaxAge { get; }
     public int MaxChildren { get; }
     public int MinProfessionals { get; }
     public List<AgeGroupRuleConstraint> Constraints { get; }
-    public AgeGroupRule(int minAge, int maxAge, int minProfessionals, int maxChildren, List<AgeGroupRuleConstraint> constraints = null)
+    public AgeGroupRule(int minAge, int maxAge, int minProfessionals, int maxChildren, List<AgeGroupRuleConstraint>? constraints = null)
     {
         MinAge = minAge;
         MaxAge = maxAge;

--- a/BKRCalculator/AgeGroupRulesFactory.cs
+++ b/BKRCalculator/AgeGroupRulesFactory.cs
@@ -1,6 +1,6 @@
 namespace KDVManager.BKRCalculator;
 
-public class AgeGroupRulesFactory
+internal class AgeGroupRulesFactory
 {
     public List<AgeGroupRule> BuildAgeGroupRules()
     {


### PR DESCRIPTION
Make the `AgeGroupRulesFactory` and `AgeGroupRule` classes internal to encapsulate their implementation details and prevent external usage.

- Mark `AgeGroupRulesFactory` and `AgeGroupRule` as internal
- Update access modifiers for internal usage only

This change improves the encapsulation of the internal logic, providing a cleaner and more controlled API surface for external consumers.