### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/LuukLabs/BKRCalculator/security/code-scanning/1](https://github.com/LuukLabs/BKRCalculator/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the least privileges required for the workflow. Based on the tasks performed in the workflow (checkout, setup, restore, build, and test), the `contents: read` permission is sufficient.

The `permissions` block should be added immediately after the `name` field at the top of the file. This ensures that the permissions apply to all jobs in the workflow unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
