### PR TITLE
docs: vertaal README naar het Nederlands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,69 @@
 # BKRCalculator
 
-BKRCalculator is a C# library that calculates the number of professionals needed based on the counts of children in different age groups. The calculation rules are based on the guidelines provided by [1Ratio](https://www.1ratio.nl/bkr/#/rekenregels/3).
+BKRCalculator is een C#-bibliotheek die berekent hoeveel beroepskrachten er minimaal nodig zijn op basis van het aantal kinderen per leeftijdsgroep. De rekenregels zijn gebaseerd op de Nederlandse beroepskracht-kindratio (BKR) zoals beschreven door [1Ratio](https://www.1ratio.nl/bkr/#/rekenregels/3).
 
-## Installation
+## Installatie
 
-To use BKRCalculator in your project, you can add it as a package from GitHub Packages using the following command:
+Voeg BKRCalculator toe aan je project als package vanaf GitHub Packages:
 
 ```bash
 $ dotnet add package BKRCalculator --version 0.2.0
 ```
 
-## Overview
+## Overzicht
 
-The BKRCalculator library includes classes for managing age group counts, and calculating the required number of professionals .
+De bibliotheek bevat klassen om het aantal kinderen per leeftijdsgroep bij te houden en om het vereiste aantal beroepskrachten te berekenen. De ratio's per leeftijd (dagopvang, vanaf 1 juli 2024) zijn: 0 jaar 1:3 · 1 jaar 1:5 · 2 jaar 1:6 · 3 jaar 1:8.
 
-## Features
+## Functies
 
-- **AgeGroupCounts:** Track counts of children in different age groups.
-- **GroupAnalyzer:** Calculate the required number of professionals based on age group counts.
+- **AgeGroupCounts:** houdt het aantal kinderen per leeftijdsgroep bij (0 t/m 3 jaar).
+- **GroupAnalyzer:** berekent het vereiste aantal beroepskrachten op basis van die aantallen.
+- **GroupAnalysisResult:** de uitkomst, inclusief een onderbouwing — welke wettelijke regel van toepassing is (`AppliedRule`) en waarom dat aantal volgt (`Basis`).
 
-## Getting Started
-To use the BKRCalculator library, follow these steps:
-- Create instances of AgeGroupCounts, and GroupAnalyzer.
-- Set counts for different age groups using AgeGroupCounts.
-- Use GroupAnalyzer to calculate the required number of professionals based on age group counts and constraints.
+## Aan de slag
+
+1. Maak een `AgeGroupCounts` aan en vul het aantal kinderen per leeftijd in.
+2. Geef dit aan `GroupAnalyzer.CalculateBKR` mee.
+3. Lees de uitkomst uit het `GroupAnalysisResult`.
 
 ```csharp
-// Example Usage
-var ageGroupCounts = new AgeGroupCounts();
-ageGroupCounts.Age1Count = 5;
-ageGroupCounts.Age2Count = 8;
-ageGroupCounts.Age3Count = 3;
+// Voorbeeld
+var ageGroupCounts = new AgeGroupCounts
+{
+    Age0Count = 0,
+    Age1Count = 5,
+    Age2Count = 8,
+    Age3Count = 3,
+};
 
-var groupAnalyzer = new GroupAnaylyzer();
-int calculatedProfessionals = groupAnalyzer.CalculateBKR(ageGroupCounts);
-Console.WriteLine($"Calculated number of professionals: {calculatedProfessionals}");
+var groupAnalyzer = new GroupAnalyzer();
+GroupAnalysisResult result = groupAnalyzer.CalculateBKR(ageGroupCounts);
+
+Console.WriteLine($"Aantal kinderen: {result.TotalChildren}");
+Console.WriteLine($"Geldige samenstelling: {result.HasSolution}");
+Console.WriteLine($"Benodigde beroepskrachten: {result.Professionals}");
 ```
 
-### Contributing
-Contributions are welcome! If you have any ideas, suggestions, or bug reports, please create an issue or submit a pull request.
+### De onderbouwing uitlezen
+
+`GroupAnalysisResult` legt ook uit *waarom* een bepaald aantal van toepassing is. Dat is taalonafhankelijk: de bibliotheek geeft de feiten, de consument (frontend) maakt er leesbare tekst van.
+
+```csharp
+if (result.AppliedRule is { } rule)
+{
+    // De toegepaste wettelijke norm.
+    Console.WriteLine($"Leeftijdsband {rule.MinAge}-{rule.MaxAge}, " +
+                      $"max {rule.MaxChildren} kinderen, " +
+                      $"minimaal {rule.MinProfessionals} beroepskrachten");
+
+    foreach (var ratio in rule.Ratios)
+        Console.WriteLine($"  {ratio.Age} jaar -> 1:{ratio.MaxChildrenPerProfessional}");
+}
+
+// Waarom dit aantal? GroupSizeMinimum, RatioCalculation of OneChildLessSafeguard.
+Console.WriteLine($"Basis: {result.Basis}");
+```
+
+## Bijdragen
+
+Bijdragen zijn welkom! Heb je ideeën, suggesties of een bug gevonden? Maak een issue aan of dien een pull request in.


### PR DESCRIPTION
## Wat

De README is herschreven in het Nederlands — de BKR-rekenregels zijn Nederlands, dus de documentatie nu ook.

## Wijzigingen

- **Vertaling** naar het Nederlands.
- **Codevoorbeeld gecorrigeerd:**
  - `GroupAnaylyzer` → `GroupAnalyzer` (typefout).
  - `CalculateBKR` geeft een `GroupAnalysisResult` terug, geen `int` — het voorbeeld leest nu `result.Professionals` uit.
  - `Age0Count` wordt nu ook ingesteld.
- **Onderbouwing gedocumenteerd:** hoe je `AppliedRule`, `Ratios` en `Basis` uitleest (uit #158).
- **Ratio's per leeftijd** vermeld (dagopvang, vanaf 1 juli 2024): 0 jr 1:3 · 1 jr 1:5 · 2 jr 1:6 · 3 jr 1:8.

https://claude.ai/code/session_01PKW6hd6Ev9zULrFMEfBw7q